### PR TITLE
Updates for admagic

### DIFF
--- a/lib/fedex/request/freight_rate.rb
+++ b/lib/fedex/request/freight_rate.rb
@@ -21,8 +21,39 @@ module Fedex
               }
             }
           }
-          add_freight_shipment_detail(xml)
+          add_unified_freight_shipment_detail(xml) if (@freight_account[:account_number] = '300288790')
+          add_freight_shipment_detail(xml) unless (@freight_account[:account_number] = '300288790')
           xml.RateRequestTypes "PREFERRED"
+        }
+      end
+
+      def add_unified_freight_shipment_detail(xml)
+        xml.FreightShipmentDetail{
+          xml.FedExFreightAccountNumber @freight_account[:account_number]
+          xml.FedExFreightBillingContactAndAddress{
+            xml.Contact{
+              xml.CompanyName @shipper[:name]
+              xml.PhoneNumber @shipper[:phone_number]
+            }
+            xml.Address{
+              xml.StreetLines @freight_account[:address]
+              xml.City @freight_account[:city]
+              xml.StateOrProvinceCode @freight_account[:state]
+              xml.PostalCode @freight_account[:postal_code]
+              xml.CountryCode @freight_account[:country_code]
+            }
+          }
+          xml.Role 'SHIPPER'
+          @packages.each do |package|
+            xml.LineItems{
+              xml.FreightClass package[:freight_class] || 'CLASS_070'
+              xml.Packaging 'PALLET'
+              xml.Weight{
+                xml.Units package[:weight][:units]
+                xml.Value package[:weight][:value]
+              }
+            }
+          end
         }
       end
 


### PR DESCRIPTION
Admagic has a unified account number for its regular and freight accounts.  The way this was initially setup, it accounts for a third party freight account.  This is a stopgap fix for Breaking Games warehouse for the time being.  I doubt this will require a more permanent change in the future.